### PR TITLE
Fix double 'keys' in index

### DIFF
--- a/_sources/index.rst.txt
+++ b/_sources/index.rst.txt
@@ -7,7 +7,7 @@
 Vespene
 -------
 
-Vespene is a modern, streamlined build and self-service automation platform. Vespene is 
+Vespene is a modern, streamlined build and self-service automation platform. Vespene is
 designed to combat chaos in complex software development and operations environments.
 
 Our mission is simple: get great people together to build the ultimate system we all want to use.
@@ -25,9 +25,9 @@ and any number of backend build "worker" processes, all of which share the datab
 Continuous Integration
 ======================
 
-While equally usable for small shops, Vespene was inspired by the needs of large organizations with hundreds of microservice projects in dozens of languages. 
+While equally usable for small shops, Vespene was inspired by the needs of large organizations with hundreds of microservice projects in dozens of languages.
 
-When organizations start to have too many projects, they need an easy way to share values and code snippets between those projects. To support this we have Jinja2 templating of build scripts via :ref:`variables` built-in. Variables can be defined across multiple hierarchies of objects throughout Vespene, and are also directly consumable by loading "vespene.json" from the build root, which interfaces nicely with any application that can read YAML or JSON. 
+When organizations start to have too many projects, they need an easy way to share values and code snippets between those projects. To support this we have Jinja2 templating of build scripts via :ref:`variables` built-in. Variables can be defined across multiple hierarchies of objects throughout Vespene, and are also directly consumable by loading "vespene.json" from the build root, which interfaces nicely with any application that can read YAML or JSON.
 
 As you might expect of any build system, builds can be launched manually, triggered from commits with :ref:`webhooks`, or set off on timers with :ref:`scheduling`.
 
@@ -36,7 +36,7 @@ Automation, "DevOps", Etc
 
 Projects in vespene don't need to just represent source code. Projects can also launch automation scripts or software of any kind, whether being pulled from source control or just scripts defined in Vespene. These jobs can include security scans, cloud topology changes, database backups, launching functional tests, and more.
 
-While not all automation tools are SSH-powered, many are. Vespene can memorize important :ref:`ssh` keys and use them on your behalf, using built-in support for ssh-agent.
+While not all automation tools are SSH-powered, many are. Vespene can memorize important :ref:`ssh` and use them on your behalf, using built-in support for ssh-agent.
 
 Helping with the self-service magic, projects can ask interactive questions before they are launched with :ref:`launch_questions`, providing unpriveledged users a simple interface to invoke specific tasks without needing full shell access. These questions can be drop-downs, multiple choice, or fill in the blank.
 
@@ -55,7 +55,7 @@ Vespene is also straightforward to :ref:`setup` and maintain. GitHub organizatio
 Extensibility
 =============
 
-Finally, Vespene has an exceptionally concise and extensible codebase. Nearly all policy in Vespene is implemented in :ref:`plugins`, and more areas for pluggability will be added over time. 
+Finally, Vespene has an exceptionally concise and extensible codebase. Nearly all policy in Vespene is implemented in :ref:`plugins`, and more areas for pluggability will be added over time.
 
 Status
 ======
@@ -79,5 +79,3 @@ Links
 * `GitHub <http://github.com/vespene-io/vespene.>`_ - code checkouts, pull requests, and bug reports
 * `Homepage <http://vespene.io>`_ - homepage, low-traffic announcement list signup
 * `@vespene_io <http://twitter.com/vespene_io>`_ and `@laserllama <http://twitter.com/laserllama>`_ - twitter
-
-


### PR DESCRIPTION
Removes duplicate 'keys' in the SSH Keys reference sentence.

Also auto-trimmed some trailing whitespace.

----

I was going to fix 

    python manage.py tutorial_setup.

In http://docs.vespene.io/tutorial.html#initialization, but I wasn't sure if the trailing period should be at the end or not. It seems, unusual to me and I haven't set up Vespene yet to test it out either way.